### PR TITLE
fix dns schema order

### DIFF
--- a/ingest/oni/load_dns_avro_parquet.hql
+++ b/ingest/oni/load_dns_avro_parquet.hql
@@ -48,6 +48,6 @@ TBLPROPERTIES ('avro.schema.literal'='{
 
 INSERT INTO TABLE ${hiveconf:dbname}.dns
 PARTITION (y=${hiveconf:y}, m=${hiveconf:m}, d=${hiveconf:d}, h=${hiveconf:h})
-SELECT   CONCAT(frame_day , frame_time) as treceived, unix_tstamp, frame_len,  ip_src,  ip_dst,  dns_qry_name, dns_qry_type, dns_qry_class, dns_qry_rcode, dns_a 
+SELECT   CONCAT(frame_day , frame_time) as treceived, unix_tstamp, frame_len,  ip_src,  ip_dst,  dns_qry_name, dns_qry_class, dns_qry_type, dns_qry_rcode, dns_a 
 FROM ${hiveconf:dbname}.dns_tmp
 ;


### PR DESCRIPTION
load to avro script has a column order mismatch 
 dns_qry_type
 dns_qry_class
